### PR TITLE
Ignore errors from sending the typing indicator

### DIFF
--- a/Source/Microsoft.Teams.Apps.AskHR/Bots/AskHRBot.cs
+++ b/Source/Microsoft.Teams.Apps.AskHR/Bots/AskHRBot.cs
@@ -659,11 +659,20 @@ namespace Microsoft.Teams.Apps.AskHR.Bots
         }
 
         // Send typing indicator to the user.
-        private Task SendTypingIndicatorAsync(ITurnContext turnContext)
+        private async Task SendTypingIndicatorAsync(ITurnContext turnContext)
         {
-            var typingActivity = turnContext.Activity.CreateReply();
-            typingActivity.Type = ActivityTypes.Typing;
-            return turnContext.SendActivityAsync(typingActivity);
+            try
+            {
+                var typingActivity = turnContext.Activity.CreateReply();
+                typingActivity.Type = ActivityTypes.Typing;
+                await turnContext.SendActivityAsync(typingActivity);
+            }
+            catch (Exception ex)
+            {
+                // Do not fail on errors sending the typing indicator
+                this.telemetryClient.TrackTrace($"Failed to send a typing indicator: {ex.Message}", SeverityLevel.Warning);
+                this.telemetryClient.TrackException(ex);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Bots posting typing-indicators to users in Europe region are receiving 502s at this time, as typing indicator support is scaled down temporarily to provide more resources to other scenarios.

This change suppresses the exception thrown by sending the typing indicator, so that a failure to post the indicator is not a fatal error. The exception is still logged to App Insights so that the admin can monitor the ultimate resolution of this issue.